### PR TITLE
Trivial: Change prefpane label

### DIFF
--- a/Resources/Prefpane_Info.plist
+++ b/Resources/Prefpane_Info.plist
@@ -25,7 +25,7 @@
 	<key>NSPrefPaneIconFile</key>
 	<string></string>
 	<key>NSPrefPaneIconLabel</key>
-	<string>SwiftDefaultApps</string>
+	<string>Swift DefaultApps</string>
 	<key>NSPrincipalClass</key>
 	<string>SWDAMainPrefPane</string>
 </dict>


### PR DESCRIPTION
Current label is a bit long and bumps into the label of adjacent panes, so I just inserted a space after "Swift".
![new_title](https://user-images.githubusercontent.com/615115/103549823-f6948200-4e75-11eb-8c11-5b8ac571227c.jpg)

