### PR TITLE
fix potential double slash in `$appDir`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The **Do Nothing** dummy app needs to be launched before you can use it in the p
 ```bash
 appDir="/Library/PreferencePanes/SwiftDefaultApps.prefPane/Contents/Resources/ThisAppDoesNothing.app"
 
-if ! [[ -d "$appDir" ]]; then appDir="$HOME/$appDir"; fi
+if ! [[ -d "$appDir" ]]; then appDir="$HOME$appDir"; fi
 
 # Remove quanrantine flag
 xattr -d com.apple.quarantine "$appDir"


### PR DESCRIPTION
`$appDir` in the script for `ThisAppDoesNothing.app` results to either:
`/Library/PreferencePanes/SwiftDefaultApps.prefPane/Contents/Resources/ThisAppDoesNothing.app`
or
`/Users/username//Library/PreferencePanes/SwiftDefaultApps.prefPane/Contents/Resources/ThisAppDoesNothing.app`
In the second case, you can see `//` right after the home directory which is what this PR eliminates.